### PR TITLE
Updated Share Options banner color. Everything that's supposed to be red...

### DIFF
--- a/Android/res/layout/shareoptions.xml
+++ b/Android/res/layout/shareoptions.xml
@@ -12,7 +12,7 @@
         style="?android:attr/listSeparatorTextViewStyle"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:background="#6D7B8D"
+        android:background="#ff0000" 
         android:paddingBottom="2dip"
         android:paddingLeft="5dip"
         android:paddingTop="2dip"


### PR DESCRIPTION
... should now be red. For issue: Paint the App Red (#11).

This is the last of a series of changes to turn all the gray stuff red. It looks like this was the last detail missing. Color should now be consistent throughout the app. 

Group: Katharine Brinker, Sreenidhi Pundi Muralidharan (original claimer of the issue), and Duy Truong. 
