### PR TITLE
Just fixed image not loading issue by encoding image url

### DIFF
--- a/JavaCommon/src/edu/sjsu/cinequest/comm/ImageManager.java
+++ b/JavaCommon/src/edu/sjsu/cinequest/comm/ImageManager.java
@@ -59,6 +59,13 @@ public class ImageManager
     private Object fetchImage(String imageUrl, boolean usePersistentCache) throws IOException
     {
         Object image = null;
+        // the problem of image not loading is right here because of url encoding
+        // check if there are spaces in image url
+        if ((imageUrl.contains("image") || imageUrl.contains(".jpg")) && imageUrl.contains(" ")) {
+            // replace " " with "%20"
+            imageUrl = imageUrl.replace(" ", "%20");
+        }
+        
         HttpURLConnection connection = ConnectionHelper.open(imageUrl);
         if (!connection.getHeaderField("content-type").startsWith("image"))
         {


### PR DESCRIPTION
Hi Professor,

I just fixed the image not loading issue that our Cinequest team mentioned in class on Monday. The problem was the image url encoding. Some of the thumb image urls have spaces, so I encoded them. Finally, all the images will be able to load upon clicking.

Happy Thanksgiving!
Duc Nguyen
