### PR TITLE
Fixed text size issue and app not building issue

### DIFF
--- a/Android/src/edu/sjsu/cinequest/MainTab.java
+++ b/Android/src/edu/sjsu/cinequest/MainTab.java
@@ -31,7 +31,7 @@ public class MainTab extends TabActivity {
 		spec = tabHost
 				.newTabSpec("news")
 				.setIndicator("News",
-						getResources().getDrawable(R.drawable.news))
+						getResources().getDrawable(R.drawable.ic_tab_news))
 				.setContent(intent);
 		tabHost.addTab(spec);
 
@@ -42,7 +42,7 @@ public class MainTab extends TabActivity {
 		spec = tabHost
 				.newTabSpec("index")
 				.setIndicator("Index",
-						getResources().getDrawable(R.drawable.film_icon))
+						getResources().getDrawable(R.drawable.ic_tab_film))
 				.setContent(intent);
 		// Add it to the tab
 		tabHost.addTab(spec);
@@ -52,7 +52,7 @@ public class MainTab extends TabActivity {
 		spec = tabHost
 				.newTabSpec("schedule")
 				.setIndicator("Schedule",
-						getResources().getDrawable(R.drawable.events_icon))
+						getResources().getDrawable(R.drawable.ic_tab_schedule))
 				.setContent(intent);
 		tabHost.addTab(spec);
 
@@ -60,7 +60,7 @@ public class MainTab extends TabActivity {
 		spec = tabHost
 				.newTabSpec("My Cinequest")
 				.setIndicator("My Cinequest",
-						getResources().getDrawable(R.drawable.schedule_icon))
+						getResources().getDrawable(R.drawable.ic_tab_event))
 				.setContent(intent);
 		tabHost.addTab(spec);
 


### PR DESCRIPTION
"My Cinequest" tab no longer srolls; all of the text fits on the tab. Also fixed the problem where the app wasn't building due to missing resources. I don't actually have those resources, but I made the necessary changes for the app to build now. Not sure if that can count as two issues, though I guess that's technically two different issues with the app that've been fixed, but at least the text issue is resolved now. Group: Katharine Brinker, Sreenidhi Pundi Muralidharan, Duy Truong
